### PR TITLE
Fix the hierarchial sort in elasticsearch

### DIFF
--- a/oceandb_elasticsearch_driver/plugin.py
+++ b/oceandb_elasticsearch_driver/plugin.py
@@ -215,7 +215,7 @@ class Plugin(AbstractPlugin):
             o = []
             for i in sort.keys():
                 if self.driver._es.indices.get_field_mapping(i)[self.driver._index]['mappings']['_doc'][i]['mapping'][
-                    i]['type'] == 'text':
+                    i.split('.')[-1]]['type'] == 'text':
                     o.append({i + ".keyword": ('asc' if sort.get(i) == 1 else 'desc')}, )
                 else:
                     o.append({i: ('asc' if sort.get(i) == 1 else 'desc')}, )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -98,3 +98,21 @@ def test_full_text_query():
     es.delete(4)
     es.delete(5)
     es.delete(6)
+
+
+def test_full_text_query_tree():
+    es.write({"father": {"son": "test1"}}, 1)
+    es.write({"father": {"son": "test2"}}, 2)
+    es.write({"father": {"son": "test3"}}, 3)
+    es.write({"father": {"son": "foo4"}}, 4)
+    es.write({"father": {"son": "foo5"}}, 5)
+    es.write({"father": {"son": "test6"}}, 6)
+    search_model = FullTextModel('foo?', {'father.son': -1}, offset=6, page=0)
+    assert len(es.text_query(search_model)) == 2
+    assert es.text_query(search_model)[0]['father']['son'] == 'foo5'
+    es.delete(1)
+    es.delete(2)
+    es.delete(3)
+    es.delete(4)
+    es.delete(5)
+    es.delete(6)


### PR DESCRIPTION
## Description
Now it is fixed the hierarchical sort, you can sort using the dot to separate father of son `  "sort": {"base.author": 1}`
## Is this PR related with an open issue?
No
## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [X] Follows the code style of this project.
- [X] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->](https://media.giphy.com/media/MNBBM4Uug4ZAQ/giphy.gif)