### PR TITLE
allow querying for custom fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,20 @@ When you want to instantiate an Oceandb plugin you can provide the next environm
 
 ## Queries
 
-Currently we are supporting a list of queries predefined in order to improve the search:
-All this queries present a common format: 
-```query:{"name":[args]}```
+You can query the DDO using predefined fields or provide the path to the desired fields yourself.
 
-This queries are the following:
+All queries use a common format:
+```json
+{
+  "query": {
+    "field": ["value1", "value2"]
+  }
+}
+```
+
+### Querying predefined fields
+
+Predefined fields include:
 - price
     
     Could receive one or two parameters. If you only pass one assumes that your query is going to start from 0 to your value.
@@ -148,6 +157,19 @@ This queries are the following:
     Retrieve all the values that match with the text sent.
     
     `{"text":["weather"]}`
+
+### Querying custom fields
+
+You can also query the DDO by value of any field. To do that, you will need to provide the full path inside the metadata instead of just the field name.
+
+For example:
+```json
+{
+  "query": {
+    "service.attributes.additionalInformation.customField": ["customValue1", "customValue2"]
+  }
+}
+```
 
 
 ## Code style

--- a/oceandb_elasticsearch_driver/utils.py
+++ b/oceandb_elasticsearch_driver/utils.py
@@ -37,10 +37,11 @@ def query_parser(query):
     }
     for key, value in query.items():
         if key not in key_to_index_and_maker:
-            logger.error('The key %s is not supported by OceanDB.' % key)
-            raise Exception('The key %s is not supported by OceanDB.' % key)
+            index = key
+            query_maker = create_query
+        else:
+            index, query_maker = key_to_index_and_maker[key]
 
-        index, query_maker = key_to_index_and_maker[key]
         if index is not None:
             query_must = query_maker(query_must, index, value)
         else:

--- a/tests/ddo_example.py
+++ b/tests/ddo_example.py
@@ -301,6 +301,7 @@ ddo_sample = {
                     ],
                     "inLanguage": "en",
                     "tags": "weather, uk, 2011, temperature, humidity",
+                    "customField": "customValue"
                 }
             }
         }

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -120,6 +120,9 @@ def test_search_query():
     assert len(es.query(QueryModel({'text': ['2011']}))[0]) == 1
     assert len(es.query(QueryModel({'text': ['2011', 'uuuukkk', 'temperature']}))[0]) == 1
 
+    assert len(es.query(QueryModel({'service.attributes.additionalInformation.customField': ['customValue']}))[0]) == 1
+    assert len(es.query(QueryModel({'service.attributes.additionalInformation.nonExistentField': ['customValue']}))[0]) == 0
+
     search_model = QueryModel({'price': ["0", "12"], 'text': ['Weather']})
     assert es.query(search_model)[0][0]['id'] == ddo_sample['id']
     es.delete(ddo_sample['id'])
@@ -227,6 +230,9 @@ def test_query_parser():
 
     query = {'categories': ['weather', 'other']}
     assert query_parser(query) == ({"bool": {"must": [{"bool": {"should": [{"match": {"service.attributes.additionalInformation.categories": "weather"}}, {"match": {"service.attributes.additionalInformation.categories": "other"}}]}}]}})
+
+    query = {'service.attributes.additionalInformation.customField': ['customValue']}
+    assert query_parser(query) == ({"bool": {"must": [{"bool": {"should": [{"match": {"service.attributes.additionalInformation.customField": "customValue"}}]}}]}})
 
 
 def test_default_sort():


### PR DESCRIPTION
## Description

Allow searching for custom fields in the metadata by passing a full field path. This also slightly changes the previous behaviour - after this change searching for a field that doesn't exist will return an empty list of results instead of throwing an error.

## Is this PR related with an open issue?

Don't think so

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation